### PR TITLE
Scalar colorize elements

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#fe7d37" d="M63 0h36v20H63z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">56%</text>
-        <text x="80" y="14">56%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">60%</text>
+        <text x="80" y="14">60%</text>
     </g>
 </svg>

--- a/parser_tool/apicache.py
+++ b/parser_tool/apicache.py
@@ -1,0 +1,46 @@
+from django.core.cache import cache
+
+import hashlib
+import json
+
+from . import tokenizer
+from . import lemmatizer
+from . import htmlcolorizer
+
+
+def lemmatize_text(text):
+    cache_key = "lemmatize_text:" + hashlib.md5(text.encode()).hexdigest()
+    lemmatized_data = cache.get(cache_key)
+    if lemmatized_data is None:
+        lemmatized_data = lemmatizer.lemmatize_text(text)
+        cache.set(cache_key, lemmatized_data)
+    return lemmatized_data
+
+
+def tokenize_and_tag(text):
+    cache_key = "tokenize_and_tag:" + hashlib.md5(text.encode()).hexdigest()
+    tokens = cache.get(cache_key)
+    if tokens is None:
+        tokens = tokenizer.tokenize_and_tag(text)
+        cache.set(cache_key, tokens)
+    return tokens
+
+
+def colorize_html(html, color_attribute):
+    cache_key = "colorize_html:" + hashlib.md5(color_attribute.encode() + html.encode()).hexdigest()
+    output = cache.get(cache_key)
+    if output is None:
+        colorizer = htmlcolorizer.HtmlColorizer(html, color_attribute=color_attribute)
+        output = colorizer.colorize()
+        cache.set(cache_key, output)
+    return output
+
+
+def colorize_elements(elements, color_attribute):
+    cache_key = "colorize_elements:" + hashlib.md5(json.dumps(elements, sort_keys=True).encode()).hexdigest()
+    output = cache.get(cache_key)
+    if output is None:
+        colorizer = htmlcolorizer.HtmlElementsColorizer(elements, color_attribute=color_attribute)
+        output = colorizer.colorize()
+        cache.set(cache_key, output)
+    return output

--- a/parser_tool/htmlcolorizer.py
+++ b/parser_tool/htmlcolorizer.py
@@ -1,8 +1,10 @@
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString
+
 import re
 
 from . import tokenizer
+from . import lemmatizer
 
 # List of colors to use when applying as an inline style
 COLOR_LIST = ['inherit', 'green', 'blue', 'indigo', 'orange', 'orange', 'black']  # for levels 0-6
@@ -18,58 +20,120 @@ DEFAULT_COLOR_ATTR = COLOR_ATTR_DATA
 SCRUB_HTML_PATTERN = re.compile(r"<[^>]*>")
 
 
-class HtmlColorizer:
+class DocumentColorizer:
     """
-    A class used to colorize the words in an HTML document according to the difficulty level of the lemma.
+    Abstract class used to colorize the words in a document according to the difficulty level of the lemma.
     """
-    def __init__(self, html_doc, color_attribute=None):
-        self.html_doc = html_doc
-        self.soup = BeautifulSoup(html_doc, 'html.parser')
+    def __init__(self, doc, **options):
+        self.doc = doc
+        self.options = options
+        self.levels = options.get('levels', None)
+        self.color_attribute = options.get('color_attribute', DEFAULT_COLOR_ATTR)
 
-        if color_attribute in COLOR_ATTR_CHOICES:
-            self.color_attribute = color_attribute
-        else:
-            self.color_attribute = DEFAULT_COLOR_ATTR
+    def colorize(self):
+        """ Returns the colorized doocument. """
+        raise NotImplementedError()
 
-    def get_doc_tokens(self):
-        """ Returns a complete list of tokens from the html document. """
-        text = SCRUB_HTML_PATTERN.sub('', self.html_doc)
-        doc_tokens = tokenizer.tokenize_and_tag(text)
-        return doc_tokens
+    def get_text(self):
+        """ Returns complete text of the document. """
+        raise NotImplementedError()
 
-    def colorize(self, lemmatized_data):
-        """ Returns the colorized HTML. """
-        canonical_token_levels = {t['canonical']: t['level'] for t in lemmatized_data['tokens']}
-        self._colorize(canonical_token_levels)
-        return str(self.soup)
+    def get_tokens(self):
+        """ Returns a complete list of tokens from the document. """
+        doc_text = self.get_text()
+        return tokenizer.tokenize_and_tag(doc_text)
 
-    def _colorize(self, canonical_token_levels):
+    def get_levels(self):
+        """ Returns a dict() mapping each token to its level. """
+        if self.levels is None:
+            doc_tokens = self.get_tokens()
+            doc_lemmatized = lemmatizer.lemmatize_tokens(doc_tokens)
+            self.levels = {t['canonical']: t['level'] for t in doc_lemmatized['tokens'] if t['level']}
+        return self.levels
+
+    def get_color_attribute(self):
+        if self.color_attribute not in COLOR_ATTR_CHOICES:
+            return DEFAULT_COLOR_ATTR
+        return self.color_attribute
+
+
+class HtmlColorizer(DocumentColorizer):
+    """
+    Colorize words in an HTML document.
+    """
+    def __init__(self, doc, **options):
+        super().__init__(doc, **options)
+
+    def get_text(self):
+        """ Returns text from the document. """
+        text = SCRUB_HTML_PATTERN.sub('', self.doc)
+        return text
+
+    def colorize(self):
+        levels = self.get_levels()
+        color_attribute = self.get_color_attribute()
+        soup = self._make_beautiful_soup()
         text_nodes = []
 
         # First extract all the text nodes from the html document
-        for child in self.soup.descendants:
+        for child in soup.descendants:
             if not hasattr(child, 'children'):
                 text_nodes.append(child)
 
         # Then replace each text node with one or more span elements that colorizes each word
         for text_node in text_nodes:
-            text = str(text_node)
-            tokens = tokenizer.tokenize_and_tag(text)
-            token_elements = self.soup.new_tag('span')
+            tokens = tokenizer.tokenize_and_tag(str(text_node))
+            token_elements = []
             for token in tokens:
-                token_level = canonical_token_levels.get(token['canonical'])
+                token_level = levels.get(token['canonical'])
                 if token_level:
                     token_level_int = int(token_level[0])
-                    element = self.soup.new_tag("span")
+                    element = soup.new_tag("span")
                     element.string = token['token']
-                    if self.color_attribute == COLOR_ATTR_DATA:
+                    if color_attribute == COLOR_ATTR_DATA:
                         element['data-level'] = token_level
-                    elif self.color_attribute == COLOR_ATTR_CLASS:
+                    elif color_attribute == COLOR_ATTR_CLASS:
                         element['class'] = 'wordlevel' + str(token_level_int)
-                    elif self.color_attribute == COLOR_ATTR_STYLE:
+                    elif color_attribute == COLOR_ATTR_STYLE:
                         element['style'] = 'color:' + COLOR_LIST[token_level_int]
                 else:
                     element = NavigableString(token['token'])
                 token_elements.append(element)
-            text_node.replace_with(token_elements.extract())
-        return self
+
+            text_node.insert_before(*token_elements)
+            text_node.extract()  # remove text node
+
+        colorized_html = str(soup)
+        return colorized_html
+
+    def _make_beautiful_soup(self):
+        return BeautifulSoup(self.doc, 'html.parser')
+
+
+class HtmlElementsColorizer(DocumentColorizer):
+    """
+    Colorizes elements in an HTML document.
+
+    The elements should be provided as a dictionary of elements where the key is an identifier
+    in the DOM and the value is the inner content of that element.
+    """
+    def __init__(self, doc, **options):
+        super().__init__(doc, **options) # doc is a dict mapping element IDs to strings
+
+    def get_text(self):
+        """ Returns text from all elements. """
+        text = " ".join(self.doc.values())
+        return text
+
+    def colorize(self):
+        levels = self.get_levels()
+        colorized_elements = {
+            element_id: self._colorize_element(value, levels) for element_id, value in self.doc.items()
+        }
+        return colorized_elements
+
+    def _colorize_element(self, element, levels):
+        options = dict(self.options)
+        options['levels'] = levels
+        html_colorizer = HtmlColorizer(element, **options)
+        return html_colorizer.colorize()

--- a/parser_tool/static/js/src/html_colorizer.js
+++ b/parser_tool/static/js/src/html_colorizer.js
@@ -8,7 +8,7 @@
     const input_html = $("#contentinput").val();
     try {
       before_colorize(input_html);
-      const output_html = await api.colorizehtml(input_html);
+      const output_html = await api.colorize_html(input_html);
       after_colorize(output_html);
     } catch(err) {
       error(err);

--- a/parser_tool/static/js/src/lib/api.js
+++ b/parser_tool/static/js/src/lib/api.js
@@ -66,14 +66,27 @@
             return jqXhr;
         }
 
-        colorizehtml(html, params) {
+        colorize_html(html, params) {
             params = params || {};
-            var url = this._url('/api/colorizehtml', params);
+            var url = this._url('/api/colorize/html', params);
             var settings = {
                 method: "POST",
                 headers: {'Content-Type':'text/html'},
                 dataType: "text",
                 data: html
+            };
+            var jqXhr = this._ajax(url, settings);
+            return jqXhr;
+        }
+
+        colorize_elements(elements, params) {
+            params = params || {};
+            var url = this._url('/api/colorize/elements', params);
+            var settings = {
+                method: "POST",
+                headers: {'Content-Type':'application/json'},
+                dataType: "json",
+                data: elements
             };
             var jqXhr = this._ajax(url, settings);
             return jqXhr;

--- a/parser_tool/tests/test_api.py
+++ b/parser_tool/tests/test_api.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from parser_tool import api

--- a/parser_tool/tests/test_htmlcolorizer.py
+++ b/parser_tool/tests/test_htmlcolorizer.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from parser_tool import tokenizer, htmlcolorizer
+from parser_tool import tokenizer
+from parser_tool import htmlcolorizer
 
 
 def tokenize_and_tag_with_levels(text, levels=None):
@@ -24,45 +25,75 @@ class TestHtmlColorizer(unittest.TestCase):
         actual_html = htmlcolorizer.SCRUB_HTML_PATTERN.sub('', input_html)
         self.assertEqual(expected_html, actual_html)
 
-    def test_get_doc_tokens(self):
+    def test_get_tokens(self):
         input_html = '<p><strong>В</strong> <b><em>этом</em></b> <span style="font-weight:bold">году.</span></p>'
         input_text = htmlcolorizer.SCRUB_HTML_PATTERN.sub('', input_html)
         expected_tokens = tokenizer.tokenize_and_tag(input_text)
-        h = htmlcolorizer.HtmlColorizer(input_html)
-        actual_tokens = h.get_doc_tokens()
+        colorizer = htmlcolorizer.HtmlColorizer(input_html)
+        actual_tokens = colorizer.get_tokens()
         self.assertEqual(expected_tokens, actual_tokens)
 
     def test_colorize_plaintext(self):
         input_html = 'Это моя семья.'
-        tokens = tokenize_and_tag_with_levels(input_html)
+        expected_tokens = tokenize_and_tag_with_levels(input_html)
         tests = [
-            (htmlcolorizer.COLOR_ATTR_STYLE, '<span><span style="color:green">Это</span> <span style="color:green">моя</span> <span style="color:green">семья</span>.</span>'),
-            (htmlcolorizer.COLOR_ATTR_DATA, '<span><span data-level="1E">Это</span> <span data-level="1E">моя</span> <span data-level="1E">семья</span>.</span>'),
-            (htmlcolorizer.COLOR_ATTR_CLASS, '<span><span class="wordlevel1">Это</span> <span class="wordlevel1">моя</span> <span class="wordlevel1">семья</span>.</span>'),
+            ('style', '<span style="color:green">Это</span> <span style="color:green">моя</span> <span style="color:green">семья</span>.'),
+            ('data', '<span data-level="1E">Это</span> <span data-level="1E">моя</span> <span data-level="1E">семья</span>.'),
+            ('class', '<span class="wordlevel1">Это</span> <span class="wordlevel1">моя</span> <span class="wordlevel1">семья</span>.'),
         ]
 
         for test in tests:
             (color_attribute, expected_html) = test
-            h = htmlcolorizer.HtmlColorizer(input_html, color_attribute)
-            actual_html = h.colorize({'tokens': tokens})
+            colorizer = htmlcolorizer.HtmlColorizer(input_html, color_attribute=color_attribute, levels={t['canonical']: t['level'] for t in expected_tokens})
+            actual_html = colorizer.colorize()
             self.assertEqual(expected_html, actual_html)
 
     def test_colorize_nested_tags(self):
         input_html = '<p><strong>В</strong> <b><em>этом</em></b> <span style="font-weight:bold">году.</span></p>'
         input_text = htmlcolorizer.SCRUB_HTML_PATTERN.sub('', input_html)
-        tokens = tokenize_and_tag_with_levels(input_text)
-        expected_html = '<p><strong><span><span data-level="1E">В</span></span></strong><span> </span><b><em><span><span data-level="1E">этом</span></span></em></b><span> </span><span style="font-weight:bold"><span><span data-level="1E">году</span>.</span></span></p>'
+        expected_tokens = tokenize_and_tag_with_levels(input_text)
+        expected_html = '<p><strong><span data-level="1E">В</span></strong> <b><em><span data-level="1E">этом</span></em></b> <span style="font-weight:bold"><span data-level="1E">году</span>.</span></p>'
 
-        h = htmlcolorizer.HtmlColorizer(input_html, htmlcolorizer.COLOR_ATTR_DATA)
-        actual_html = h.colorize({'tokens': tokens})
+        colorizer = htmlcolorizer.HtmlColorizer(input_html, color_attribute='data', levels={t['canonical']: t['level'] for t in expected_tokens})
+        actual_html = colorizer.colorize()
+
         self.assertEqual(expected_html, actual_html)
 
     def test_colorize_broken_html(self):
         input_html = '<Это моя>'
         input_text = htmlcolorizer.SCRUB_HTML_PATTERN.sub('', input_html)
-        tokens = tokenize_and_tag_with_levels(input_text)
-        expected_html = '<span>&lt;Это моя&gt;</span>'
+        expected_tokens = tokenize_and_tag_with_levels(input_text)
+        expected_html = '&lt;Это моя&gt;'
 
-        h = htmlcolorizer.HtmlColorizer(input_html, htmlcolorizer.COLOR_ATTR_DATA)
-        actual_html = h.colorize({'tokens': tokens})
+        colorizer = htmlcolorizer.HtmlColorizer(input_html, color_attribute='data', levels={t['canonical']: t['level'] for t in expected_tokens})
+        actual_html = colorizer.colorize()
         self.assertEqual(expected_html, actual_html)
+
+
+class TestHtmlElementsColorizer(unittest.TestCase):
+
+    def test_colorize_multiple_elements(self):
+        elements = {
+            "8da35250": "Глава 1",
+            "f7464298": "— Приве́т! Как тебя зову́т?",
+            "2ff91b9b": "— Ле́на. А тебя?",
+        }
+        expected_tokens = tokenize_and_tag_with_levels(" ".join(elements.values()))
+        expected_result = {
+            "8da35250": "<span data-level=\"1E\">Глава</span> 1",
+            "f7464298": "— <span data-level=\"1E\">Приве́т</span>! <span data-level=\"1E\">Как</span> <span data-level=\"1E\">тебя</span> <span data-level=\"1E\">зову́т</span>?",
+            "2ff91b9b": "— <span data-level=\"1E\">Ле́на</span>. <span data-level=\"1E\">А</span> <span data-level=\"1E\">тебя</span>?",
+        }
+        colorizer = htmlcolorizer.HtmlElementsColorizer(elements, color_attribute='data', levels={t['canonical']: t['level'] for t in expected_tokens})
+        actual_result = colorizer.colorize()
+
+        self.assertEqual(sorted(expected_result.keys()), sorted(elements.keys()))
+        for element_id in elements:
+            self.assertEqual(expected_result[element_id], actual_result[element_id])
+
+    def test_colorize_empty_elements(self):
+        elements = {}
+        colorizer = htmlcolorizer.HtmlElementsColorizer(elements, color_attribute='data', levels={})
+        actual_result = colorizer.colorize()
+        self.assertIsInstance(actual_result, dict)
+        self.assertFalse(actual_result)

--- a/parser_tool/tests/test_htmlgenerator.py
+++ b/parser_tool/tests/test_htmlgenerator.py
@@ -2,7 +2,8 @@
 import unittest
 from xml.etree import ElementTree as ET
 
-from parser_tool import tokenizer, htmlgenerator
+from parser_tool import tokenizer
+from parser_tool import htmlgenerator
 
 
 class TestHtmlGenerator(unittest.TestCase):

--- a/parser_tool/tests/test_tokenizer.py
+++ b/parser_tool/tests/test_tokenizer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
+
 from parser_tool import tokenizer
 
 

--- a/visualizing_russian_tools/urls.py
+++ b/visualizing_russian_tools/urls.py
@@ -1,6 +1,6 @@
 """URL Configuration"""
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path
 from django.views.generic import TemplateView
 
 import parser_tool.views
@@ -10,12 +10,17 @@ urlpatterns = [
     path('', TemplateView.as_view(template_name='homepage.html'), name='home'),
     path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
     path('admin/', admin.site.urls),
+
+    # Tool pages
     path('text-parsing-analysis', parser_tool.views.text_parsing_analysis,  name='text_parsing_analysis'),
     path('html-colorizer', parser_tool.views.html_colorizer,  name='html_colorizer'),
     path('mini-story-creator', parser_tool.views.mini_story_creator,  name='mini_story_creator'),
-    path('api/parsetext', parser_tool.api.text_parser_api_view, name='api-parse-text'),
-    path('api/colorizehtml', parser_tool.api.html_colorizer_api_view, name='api-parse-html'),
-    path('api/lemmatize', parser_tool.api.lemmatize_api_view, name='api-lemmatize'),
-    path('api/tokenize', parser_tool.api.tokenize_api_view, name='api-tokenize'),
-    path('api/lemma', parser_tool.api.lemma_api_view, name='api-lemma'),
+
+    # API endpoints
+    path('api/parsetext', parser_tool.api.TextParserAPIView.as_view(), name='api-parse-text'),
+    path('api/lemmatize', parser_tool.api.LemmatizeAPIView.as_view(), name='api-lemmatize'),
+    path('api/tokenize', parser_tool.api.TokenizeAPIView.as_view(), name='api-tokenize'),
+    path('api/lemma', parser_tool.api.LemmaAPIView.as_view(), name='api-lemma'),
+    path('api/colorize/html', parser_tool.api.DocumentColorizerAPIView.as_view(), name='api-colorize-html'),
+    path('api/colorize/elements', parser_tool.api.ElementsColorizerAPIView.as_view(), name='api-colorize-elements'),
 ]


### PR DESCRIPTION
Added Scalar integration API endpoint for colorizing a set of HTML endpoints. This enables the client to batch colorize parts of a page. Note that the keys used to identify the elements are opaque to the server (intended for use by the client).

Example:

**POST http://localhost:8000/api/colorize/elements**

```json
{
   "elements":{
      "f7464298-7a7a-4b41-8e51-f1ddc005576d":"— Приве́т! Как тебя зову́т?",
      "2ff91b9b-2fe9-4665-bbc5-1dd4c5288b9c":"— Ле́на. А тебя?",
      "3c28e678-5f64-43ec-a391-6fa16cadef00":"— Ви́ктор. Очень прия́тно."
   }
}
```

Response:

```json
{
    "status": "success",
    "data": {
        "elements": {
            "f7464298-7a7a-4b41-8e51-f1ddc005576d": "— <span data-level=\"1E\">Приве́т</span>! <span data-level=\"1E\">Как</span> <span data-level=\"1E\">тебя</span> <span data-level=\"1E\">зову́т</span>?",
            "2ff91b9b-2fe9-4665-bbc5-1dd4c5288b9c": "— Ле́на. <span data-level=\"1E\">А</span> <span data-level=\"1E\">тебя</span>?",
            "3c28e678-5f64-43ec-a391-6fa16cadef00": "— Ви́ктор. <span data-level=\"1E\">Очень</span> <span data-level=\"1E\">прия́тно</span>."
        }
    }
}
```
