### PR TITLE
Increase text parser limit

### DIFF
--- a/parser_tool/api.py
+++ b/parser_tool/api.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 class BaseAPIView(View):
-    MAX_BODY_SIZE = 500000
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
@@ -29,15 +28,11 @@ class BaseAPIView(View):
     def get_request_body_html(self, request):
         if not request.content_type.startswith("text/html"):
             raise JsonBadRequest("Expected HTML content type header")
-        if len(request.body.decode('utf-8')) > self.MAX_BODY_SIZE:
-            raise ValueError("Submitted request is too large (maximum {max_size:,} characters).".format(max_size=self.MAX_BODY_SIZE))
         return request.body.decode('utf-8')
 
     def get_request_body_json(self, request):
         if request.content_type != "application/json":
             raise JsonBadRequest("Expected JSON content type header")
-        if len(request.body.decode('utf-8')) > self.MAX_BODY_SIZE:
-            raise ValueError("Submitted request is too large (maximum {max_size:,} characters).".format(max_size=self.MAX_BODY_SIZE))
         try:
             body = json.loads(request.body.decode('utf-8'))
         except ValueError:

--- a/parser_tool/static/js/src/text_parsing_analysis.js
+++ b/parser_tool/static/js/src/text_parsing_analysis.js
@@ -256,12 +256,16 @@
       $("#textinfo").html('');
     },
     getCounts: function() {
-      var counts = {0: 0, 1: 0, 2: 0, 3: 0, 4: 0};
-      $('.word[data-level]').each(function(index, el) {
-          counts[parseInt($(el).attr("data-level")[0])] += 1;
+      var counts = {total: 0, 0: 0, 1: 0, 2: 0, 3: 0, 4: 0};
+      var elementList = document.querySelectorAll('.word');
+      elementList.forEach(function(el, index) {
+        counts.total += 1;
+        if('level' in el.dataset) {
+          counts[parseInt(el.dataset.level, 10)] += 1;
+        } else {
+          counts[0] += 1;
+        }
       });
-      counts[0] = $('.word').length - $('.word[data-level]').length;
-      counts.total = counts[0] + counts[1] + counts[2] + counts[3] + counts[4];
       return counts;
     },
     generateCharts: function() {
@@ -280,9 +284,8 @@
     },
     showTextInfo: function() {
       var counts = this.counts;
-      var wl = $('.word').length;
       var html = '';
-      html += '<div>Word Count: <span class="numbers mr-4"> ' + wl + '</span></div>';
+      html += '<div>Word Count: <span class="numbers mr-4"> ' + counts.total + '</span></div>';
       html += '<div>Unparsed Count: <span class="numbers mr-4"> ' + counts[0] + '</span></div>';
       html += '<div>L1 Count: <span class="numbers mr-4"> ' + counts[1] + '</span></div>';
       html += '<div>L2 Count: <span class="numbers mr-4"> ' + counts[2] + '</span></div>';
@@ -291,7 +294,7 @@
       html += '<button type="button" id="textinfocopy" class="btn btn-secondary btn-sm">Copy to clipboard</button>';
       html += '<div id="textinfocsv" style="display:none;">';
       html += ['Word Count', 'Unparsed', 'L1', 'L2', 'L3', 'L4'].join(",") + "<br>";
-      html += [wl, counts[0], counts[1], counts[2], counts[3], counts[4]].join(",") + "\n";
+      html += [counts.total, counts[0], counts[1], counts[2], counts[3], counts[4]].join(",") + "\n";
       html += '</div>'; 
       $('#textinfo').html(html);
     },
@@ -386,12 +389,14 @@
     },
     onClickWord: function(e) {
       var $el = $(e.target);
-      if($el.hasClass("highlight")) {
-        $el.removeClass("highlight");
+      if(e.target.classList.contains("highlight")) {
+        e.target.classList.remove("highlight");
         wordInfoCtrl.reset();
       } else {
-        $(".word.highlight").removeClass("highlight");
-        $el.addClass("highlight");
+        document.querySelectorAll(".word.highlight").forEach(function(el) {
+          el.classList.remove("highlight");
+        });
+        e.target.classList.add("highlight");
         var form_ids = parsedTextCtrl.getElementDataFormIds($el);
         var word_info = parseService.getWordInfo(form_ids)
         wordInfoCtrl.setPosition({top: $el.position().top });

--- a/visualizing_russian_tools/settings/base.py
+++ b/visualizing_russian_tools/settings/base.py
@@ -118,6 +118,9 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [ os.path.join(BASE_DIR, "static") ]
 STATIC_ROOT = os.path.join(ROOT_DIR, 'http_static')
 
+# Max size in bytes that the request body can be (default: 2621440, i.e. 2.5MB)
+DATA_UPLOAD_MAX_MEMORY_SIZE = 2097152 # 2MB
+
 # Logging
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
Increases the text parser limit to 2MB, which translates to roughly 1048576 cyrillic characters (since utf-8 cyrillic is encoded in 2 bytes). The actual number of characters will vary. Since the previous limit was 400,000 characters, this roughly translates into an increase from 800K to 2MB, or 162% increase.

Note that this PR required a change to the JS, since that size text was causing an issue with jQuery (maximum call stack exceeded when counting the number of words in the text).