### PR TITLE
Update word info UI

### DIFF
--- a/parser_tool/static/css/text_parsing_analysis.css
+++ b/parser_tool/static/css/text_parsing_analysis.css
@@ -82,83 +82,24 @@ pre.words.mask.level4 .word:not(.level4) {
 }
 
 /* miscellaneous text */
-dl dd {
-    margin-inline-start: 20px;
-}
-dl dd i {
-    font-style: normal;
-    color: #990000;
-}
-
-.underline {
-    text-decoration: underline;
-}
-
-.indent {
-    margin-left: 3em;
+.underline { text-decoration: underline; }
+.indent { margin-left: 3em; }
+.wordinfo-heading { 
+    font-weight: bold;
+ }
+ul.wordinfo-details { 
+    list-style-type: none; 
+    margin-inline-start: 20px;  
+    padding-left: 0; }
+ul.wordinfo-details i { 
+    font-style: normal; 
+    color: #990000; 
 }
 
 /* resize heading elements inside the container */
-.container h1 {
-    font-size: 2rem;
-}
-
-.container h2 {
-    font-size: 1.75rem;
-}
-
-.container h3 {
-    font-size: 1.5rem;
-}
-
-.container h4 {
-    font-size: 1.25rem;
-}
-
-.container h5 {
-    font-size: 1rem;
-}
-
-.container h6 {
-    font-size: .75rem;
-}
-
-/* tabs */
-.tabs {
-    display: flex;
-    flex-wrap: wrap;
-}
-
-.tab-radio {
-    position: absolute;
-    opacity: 0;
-}
-
-.tab-label {
-    width: 100%;
-    background: #fff;
-    border: 1px solid #dedede;
-    cursor: pointer;
-    padding: 6px 12px;
-    cursor: pointer;
-    transition: background .3s, color .3s;
-    border-radius: 0.3rem;
-}
-
-.tab-label:active {
-    background: #ccc;
-}
-
-.tab-label:hover, input.tab-radio:checked + .tab-label {
-    background: #dedede;
-}
-
-.tab-content {
-    display: none;
-    width: 100%;
-    padding: 5px 0;
-}
-
-input.tab-radio:checked + .tab-label + .tab-content {
-    display: block;
-}
+.container h1 { font-size: 2rem; }
+.container h2 { font-size: 1.75rem; }
+.container h3 { font-size: 1.5rem; }
+.container h4 { font-size: 1.25rem; }
+.container h5 { font-size: 1rem; }
+.container h6 { font-size: .75rem; }

--- a/parser_tool/static/css/text_parsing_analysis.css
+++ b/parser_tool/static/css/text_parsing_analysis.css
@@ -1,5 +1,5 @@
 #analysis {
-    padding-bottom: 25vh;
+    padding-bottom: 10vh;
 }
 #parsed {
     position: relative;
@@ -7,7 +7,6 @@
     line-height: 1.5em;
     white-space: pre-wrap; /* Note: this seems to help with copy & paste to word... */
     color: black; /* Ensure that non-word characters (e.g. space and punctuation) is black */
-    margin-bottom: 400px;
 }
 
 pre.words {

--- a/parser_tool/static/css/text_parsing_analysis.css
+++ b/parser_tool/static/css/text_parsing_analysis.css
@@ -1,3 +1,6 @@
+#analysis {
+    padding-bottom: 25vh;
+}
 #parsed {
     position: relative;
     font-size: 18px;
@@ -6,22 +9,24 @@
     color: black; /* Ensure that non-word characters (e.g. space and punctuation) is black */
     margin-bottom: 400px;
 }
+
 pre.words {
     color: black;
     font-size: 18px;
     tab-size: 8; /* tab entities - &x9; or &tab; - only render in "pre" elements */
     font-family: Lato, sans-serif;
-    white-space: pre-wrap;       /* css-3 */
-    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-    white-space: -pre-wrap;      /* Opera 4-6 */
-    white-space: -o-pre-wrap;    /* Opera 7 */
-    word-wrap: break-word;       /* Internet Explorer 5.5+ */
+    white-space: pre-wrap; /* css-3 */
+    white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+    white-space: -pre-wrap; /* Opera 4-6 */
+    white-space: -o-pre-wrap; /* Opera 7 */
+    word-wrap: break-word; /* Internet Explorer 5.5+ */
 }
 
 pre.words.mask.level0 .word.parsed {
     color: #999 !important;
 }
-pre.words.mask.level1 .word:not(.level1), 
+
+pre.words.mask.level1 .word:not(.level1),
 pre.words.mask.level1-2 .word:not(.level1):not(.level2),
 pre.words.mask.level1-3 .word:not(.level1):not(.level2):not(.level3),
 pre.words.mask.level1-4 .word:not(.level1):not(.level2):not(.level3):not(.level4),
@@ -30,8 +35,7 @@ pre.words.mask.level2-3 .word:not(.level2):not(.level3),
 pre.words.mask.level2-4 .word:not(.level2):not(.level3):not(.level4),
 pre.words.mask.level3 .word:not(.level3),
 pre.words.mask.level3-4 .word:not(.level3):not(.level4),
-pre.words.mask.level4 .word:not(.level4)
-{
+pre.words.mask.level4 .word:not(.level4) {
     color: inherit !important; /* mask the color of words for particular levels*/
 }
 
@@ -40,48 +44,122 @@ pre.words.mask.level4 .word:not(.level4)
     padding: 18px;
     height: 100%;
 }
+
 #textinfo:hover > #textinfocopy {
     display: block;
 }
+
 #textinfo:not(:hover) > #textinfocopy {
     display: none;
 }
+
 #wordinfo {
     position: relative;
 }
+
 .word.parsed:hover {
     background-color: yellow;
     cursor: pointer;
 }
+
 .word.parsed.highlight {
     background-color: yellow;
 }
 
- .btn-red {
+.btn-red {
     background-color: #990000;
     color: #DEDEDE;
     font-weight: bold;
- }
- .btn-red:hover {
-    background-color: #DEDEDE;
-    color: #990000;
- }
- .btn-red:active {
-    background-color: #DEDEDE;
-    color: #990000;
- }
-
-.textinfoval {
-    color: #990000;
-    font-weight: bold;
 }
-.underline { text-decoration: underline; }
-.indent { margin-left: 3em; }
 
- /* resize heading elements inside the container */
-.container h1 { font-size: 2rem; }
-.container h2 { font-size: 1.75rem; }
-.container h3 { font-size: 1.5rem; }
-.container h4 { font-size: 1.25rem; }
-.container h5 { font-size: 1rem; }
-.container h6 { font-size: .75rem; }
+.btn-red:hover {
+    background-color: #DEDEDE;
+    color: #990000;
+}
+
+.btn-red:active {
+    background-color: #DEDEDE;
+    color: #990000;
+}
+
+/* miscellaneous text */
+dl dd {
+    margin-inline-start: 20px;
+}
+dl dd i {
+    font-style: normal;
+    color: #990000;
+}
+
+.underline {
+    text-decoration: underline;
+}
+
+.indent {
+    margin-left: 3em;
+}
+
+/* resize heading elements inside the container */
+.container h1 {
+    font-size: 2rem;
+}
+
+.container h2 {
+    font-size: 1.75rem;
+}
+
+.container h3 {
+    font-size: 1.5rem;
+}
+
+.container h4 {
+    font-size: 1.25rem;
+}
+
+.container h5 {
+    font-size: 1rem;
+}
+
+.container h6 {
+    font-size: .75rem;
+}
+
+/* tabs */
+.tabs {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.tab-radio {
+    position: absolute;
+    opacity: 0;
+}
+
+.tab-label {
+    width: 100%;
+    background: #fff;
+    border: 1px solid #dedede;
+    cursor: pointer;
+    padding: 6px 12px;
+    cursor: pointer;
+    transition: background .3s, color .3s;
+    border-radius: 0.3rem;
+}
+
+.tab-label:active {
+    background: #ccc;
+}
+
+.tab-label:hover, input.tab-radio:checked + .tab-label {
+    background: #dedede;
+}
+
+.tab-content {
+    display: none;
+    width: 100%;
+    padding: 5px 0;
+}
+
+input.tab-radio:checked + .tab-label + .tab-content {
+    display: block;
+}

--- a/parser_tool/static/js/src/lib/components.js
+++ b/parser_tool/static/js/src/lib/components.js
@@ -44,7 +44,8 @@
             return pair;
         }
 
-        _template({ label, stress_pattern_semu }) {
+        _template() {
+            const {stress_pattern_semu, show_header} = this.props;
             const [singular, plural] = this._pattern(stress_pattern_semu);
             if(!singular && !plural) {
                 return "";
@@ -61,8 +62,10 @@
                 return `<tr>${col1}${col2}</tr>`;
             }).join("");
 
+            const header = show_header ? `Stress Pattern: ${stress_pattern_semu}` : '';
+
             const table = `<table class="stress-pattern">
-                <thead><tr><th colspan="2">${label} (${stress_pattern_semu})</th></tr></thead>
+                <thead><tr><th colspan="2">${header}</th></tr></thead>
                 ${trs}
                 </table>`;
 
@@ -70,11 +73,16 @@
         }
 
         render() {
-            return this._template(this.props);
+            return this._template();
         }
 
         renderTo(selector) {
-            document.querySelector(selector).innerHTML = this._template(this.props);
+            document.querySelector(selector).innerHTML = this._template();
+        }
+        
+        static render(props) {
+            var component = new this(props);
+            return component.render();
         }
     }
 

--- a/parser_tool/static/js/src/lib/components.js
+++ b/parser_tool/static/js/src/lib/components.js
@@ -30,8 +30,7 @@
 
 
     class StressPatternTableComponent {
-        constructor({ selector, props }) {
-            this.selector = selector;
+        constructor({ props }) {
             this.props = props;
         }
 
@@ -45,7 +44,7 @@
             return pair;
         }
 
-        _template({ stress_pattern_semu }) {
+        _template({ label, stress_pattern_semu }) {
             const [singular, plural] = this._pattern(stress_pattern_semu);
             if(!singular && !plural) {
                 return "";
@@ -63,7 +62,7 @@
             }).join("");
 
             const table = `<table class="stress-pattern">
-                <thead><tr><th colspan="2">[${stress_pattern_semu}]</th></tr></thead>
+                <thead><tr><th colspan="2">${label} (${stress_pattern_semu})</th></tr></thead>
                 ${trs}
                 </table>`;
 
@@ -71,7 +70,11 @@
         }
 
         render() {
-            document.querySelector(this.selector).innerHTML = this._template(this.props);
+            return this._template(this.props);
+        }
+
+        renderTo(selector) {
+            document.querySelector(selector).innerHTML = this._template(this.props);
         }
     }
 

--- a/parser_tool/static/js/src/lib/gauges.js
+++ b/parser_tool/static/js/src/lib/gauges.js
@@ -63,8 +63,8 @@
 
             // determine size based on parent element
             const parentElement = document.querySelector(vis._parentElement);
-            const width = Math.max(parentElement.clientWidth, 200);
-            const height = Math.max(parentElement.clientHeight, 200);
+            const width = Math.max(parentElement.clientWidth, 272);
+            const height = Math.max(parentElement.clientHeight, 272);
             const radius = Math.min(width, height) / 2;
             let fontSize = Math.max(Math.round(width / 16), 14);
 

--- a/parser_tool/static/js/src/text_parsing_analysis.js
+++ b/parser_tool/static/js/src/text_parsing_analysis.js
@@ -233,7 +233,7 @@
         tabs.push({name: "Stress Patterns", content: stress_patterns_html});
       }
       if(word_info.lemmas.length > 0 && word_info.lemmas[0].pos == "verb") {
-        tabs.push({name: "Frequency", content: '<div id="wordvis"></div>' })
+        tabs.push({name: "Aspect Frequency", content: '<div id="wordvis"></div>' })
       }
 
       var tabs_html = tabs.map((tab, index) => {

--- a/parser_tool/static/js/src/text_parsing_analysis.js
+++ b/parser_tool/static/js/src/text_parsing_analysis.js
@@ -247,7 +247,7 @@
 
       var yandex_translate_link = `(<a href="https://translate.yandex.com/?lang=ru-en&text=${encodeURIComponent(form)}" rel="noreferrer noopener" style="font-size: 80%;" target="_blank">Yandex Translate</a>)`;
 
-      tabs_html = `<p>Word: <b>${form}</b>${yandex_translate_link}</p><div class="tabs">${tabs_html}</div>`;
+      tabs_html = `<p>Word: <b>${form}</b> ${yandex_translate_link}</p><div class="tabs">${tabs_html}</div>`;
 
       return tabs_html;
     },

--- a/parser_tool/static/js/src/text_parsing_analysis.js
+++ b/parser_tool/static/js/src/text_parsing_analysis.js
@@ -157,7 +157,10 @@
       if(top < 0) {
         top = 0;
       }
-      $("#worddetails").css({top: top+"px", position: "absolute"});
+      $("#worddetails").css({
+        top: top+"px",
+        position: (top == 0 ? "static": "absolute")
+      });
     },
     reset: function() {
       $("#worddetails").html("Click on a word.");

--- a/parser_tool/static/js/src/text_parsing_analysis.js
+++ b/parser_tool/static/js/src/text_parsing_analysis.js
@@ -145,22 +145,11 @@
     render: function(word_info) {
       if(word_info) {
         $("#worddetails").html(this.template(word_info));
-        this.showWordVis(word_info);
-        this.updatePosition();
+        this.update(word_info);
       } else {
         this.reset();
       }
       
-    },
-    updatePosition: function() {
-      var top = window.scrollY - (document.getElementById("wordinfo").getBoundingClientRect().top + document.documentElement.scrollTop);
-      if(top < 0) {
-        top = 0;
-      }
-      $("#worddetails").css({
-        top: top+"px",
-        position: (top == 0 ? "static": "absolute")
-      });
     },
     reset: function() {
       $("#worddetails").html("Click on a word.");
@@ -236,7 +225,7 @@
         tabs.push({name: "Stress Patterns", content: stress_patterns_html});
       }
       if(word_info.lemmas.length > 0 && word_info.lemmas[0].pos == "verb") {
-        tabs.push({name: "Aspect Frequency", content: '<div id="wordvis"></div>' })
+        tabs.push({name: "Aspectual Ratios", content: '<div id="verb-aspect-ratio-gauge"></div>' })
       }
 
       var tabs_html = tabs.map((tab, index) => {
@@ -254,28 +243,37 @@
 
       return tabs_html;
     },
-    showWordVis: function(word_info) {
-      if(word_info.lemmas.length == 0) {
-        return;
+    update: function(word_info) {
+      this.updatePosition();
+      if(word_info.lemmas.length > 0) {
+        this.drawVerbAspectRatioGauge(word_info.lemmas[0]);
       }
-      this._updateVerbFrequencyGauge(word_info.lemmas[0]);
     },
-    _updateVerbFrequencyGauge: function(lemma) {
+    updatePosition: function() {
+      var top = window.scrollY - (document.getElementById("wordinfo").getBoundingClientRect().top + document.documentElement.scrollTop);
+      if(top < 0) {
+        top = 0;
+      }
+      $("#worddetails").css({
+        top: top+"px",
+        position: (top == 0 ? "static": "absolute")
+      });
+    },
+    drawVerbAspectRatioGauge: function(lemma) {
       var aspect_pair = (lemma.pos == "verb" && lemma.aspect_pair && lemma.aspect_pair.length == 2) ? lemma.aspect_pair : [];
       var aspect_data = aspect_pair.map((v) => {
         return {"label": v.lemma_label, "value": v.lemma_count, "description": v.aspect}
       });
 
-      let element = document.createElement("div");
       if(aspect_pair.length == 2) {
         let gauge = new FrequencyGauge({
-          parentElement: "#wordvis",
+          parentElement: "#verb-aspect-ratio-gauge",
           config: { colors: ['#b74c4c', '	#999']}
         });
         gauge.data(aspect_data);
         gauge.draw();
       } else {
-        $("#wordvis").html('Frequency data not available');
+        $("#verb-aspect-ratio-gauge").html('Aspectual ratio data not available');
       }
     }
   };

--- a/parser_tool/templates/parser_tool/text_parsing_analysis.html
+++ b/parser_tool/templates/parser_tool/text_parsing_analysis.html
@@ -86,7 +86,7 @@
             </div>
             <div id="parsed"></div>
         </div>
-        <div class="col-md-3">
+        <div class="col-md-3" style="overflow-y: auto;">
             <h3 class="parser-header">Word Info</h3>
             <div id="wordinfo" class="mb-2">
                 <div id="worddetails"></div>

--- a/parser_tool/templates/parser_tool/text_parsing_analysis.html
+++ b/parser_tool/templates/parser_tool/text_parsing_analysis.html
@@ -90,8 +90,6 @@
             <h3 class="parser-header">Word Info</h3>
             <div id="wordinfo" class="mb-2">
                 <div id="worddetails"></div>
-                <div id="wordstress"></div>
-                <div id="wordvis" style="width: 250px; height: 250px;"></div>
             </div>
         </div>
     </div>

--- a/visualizing_russian_tools/templates/site_base.html
+++ b/visualizing_russian_tools/templates/site_base.html
@@ -4,4 +4,4 @@
     {% block body %}
         {% block content %}{% endblock %}
     {% endblock %}
-{% endblock %}
+{% endblock %}œ


### PR DESCRIPTION
This PR updates the _Visible Vocabulary_ word info so that each matching lemma is clearly displayed.

**Changes:**

- Stress pattern is always displayed for nouns (before it was hidden).
- Changed the positioning of the word info so that it always appears at the top of the viewport, rather than horizontally aligned with the word that was clicked on. This maximizes the amount of vertical space for displaying the word info while still keeping it in view at all times.
- Simplified template. Certain fields are now hidden if they don't apply (e.g. verb aspect is not relevant for nouns).

Note: this PR was updated (simplified) on 6/29 to reflect feedback from Steven. See example below.

|Example Noun|Example Verb|
|---|---|
|![noun](https://user-images.githubusercontent.com/1165361/123990205-8fc0d300-d997-11eb-8226-b8a7e6c10bb9.png)|![verb](https://user-images.githubusercontent.com/1165361/123990189-8d5e7900-d997-11eb-896c-c8812c1c8f9d.png)|