### PR TITLE
Add handout of 28 Oct 2021 presentation

### DIFF
--- a/visualizing_russian_tools/templates/about.html
+++ b/visualizing_russian_tools/templates/about.html
@@ -13,6 +13,11 @@
         <h2>What is Visualizing Russian?</h2>
         <p>Visualizing Russian is a suite of web-based tools for language learners, researchers, and teachers created by <a href="mailto:sclancy@fas.harvard.edu>">Steven Clancy</a>.</p>
         
+        <h2>Handouts</h2>
+        <p><a href="{% static 'handouts/ClancyPrincetonPresentation28October2021.pdf' %}">Visualizing Russian: Teaching Vocabulary at the
+            Intersection of Frequency, Grammar, and
+            Communication</a>.</p>
+
         <h2>Code and data</h2>
         <p><a href="https://github.com/harvard-atg/visualizing_russian_tools">https://github.com/harvard-atg/visualizing_russian_tools</a></p>
 


### PR DESCRIPTION
This PR adds a link to the **about** page with Steven's handout from his 28 Oct 2021 presentation at Princeton.