### PR TITLE
Add verb histogram tool to home page

### DIFF
--- a/visualizing_russian_tools/static/css/base.css
+++ b/visualizing_russian_tools/static/css/base.css
@@ -8,6 +8,7 @@ body {
 }
 main {
     flex: 3;
+    padding-bottom: 30px;
 }
 footer {
     flex: 1;

--- a/visualizing_russian_tools/templates/homepage.html
+++ b/visualizing_russian_tools/templates/homepage.html
@@ -83,19 +83,14 @@
             </div>
         </div>
     </div>
-</div>
-<!-- <div class="row" style="padding: 10px">
     <div class="col-md-4">
         <div class="card">
             <div class="card-header">Verb Histograms</div>
             <div class="card-body">
-                <p class="card-text">See real data on how verbs are used.</p>
-                <br>
-                <a href="{% url 'verb_histograms' %}" class="btn btn-primary">Enter Verb Histograms</a>
+                <p class="card-text">Counts of different constructions beginning at different distances from the verb using data from the Russian National Corpus.</p>
+                <a href="{% url 'verb_histograms' %}" class="btn btn-primary">Enter Verb Histogram Tool</a>
             </div>
         </div>
     </div>
 </div>
-<!-- <div class="row" style="padding: 10px">
-</div> -->
 {% endblock %}


### PR DESCRIPTION
This PR updates the home page so that the **Verb Histogram** tool has a card on the home page as well as being listed under the _Additional Tools_ menu.