### PR TITLE
Playing With Matches Quickstart

### DIFF
--- a/parser_tool/forms.py
+++ b/parser_tool/forms.py
@@ -2,7 +2,6 @@ from clancy_database.models import Lemma
 from django import forms
 from django.core.exceptions import ValidationError
 import logging
-from utils import list_diff
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ class WordListField(forms.Field):
         logger.info(f"WordListField validate: {qs_lemmas} length={len(qs_lemmas)}")
         actual_words = len(qs_lemmas)
         if actual_words < self.min_words:
-            not_found_words = list_diff(qs_lemmas, value)
+            not_found_words = list(set(qs_lemmas).symmetric_difference(set(value)))
             invalid_message = self.error_messages['invalid'].format(
                     min_words=self.min_words, 
                     actual_words=actual_words,

--- a/parser_tool/static/js/src/lib/utils.js
+++ b/parser_tool/static/js/src/lib/utils.js
@@ -33,7 +33,20 @@
       $([document.documentElement, document.body]).animate({scrollTop: scrollTop}, 1000);
     };
 
+    const shuffle = (a) => {
+      const cloneA = [...a];
+      let j, x;
+      for (let idx = cloneA.length - 1; idx > 0; idx--) {
+        j = Math.floor(Math.random() * (idx + 1));
+        // swap - could use destructure [a[idx], a[j]] = [a[j], a[idx]]
+        x = cloneA[idx];
+        cloneA[idx] = cloneA[j];
+        cloneA[j] = x;
+      }
+      return cloneA;
+    };
+
     // Exports
     global.app = global.app || {};
-    global.app.utils = { debounce, htmlEntities, unique, logEvent, scrollTo };
+    global.app.utils = { debounce, htmlEntities, unique, logEvent, scrollTo, shuffle };
 })(window);

--- a/parser_tool/static/js/src/playing_with_matches_options.js
+++ b/parser_tool/static/js/src/playing_with_matches_options.js
@@ -1,0 +1,33 @@
+(function ($) {
+    const { shuffle } = window.app.utils;
+
+    function initialize() {
+        const possible_words = JSON.parse(document.getElementById("possible_words_data").textContent);
+        const generate_words_btn = document.querySelector("#generate-words");
+        const words_textarea = document.querySelector("#id_words");
+        const word_count = document.querySelector("#wordcount");
+
+        // Generate a list of random words
+        function generate_words(possible_words) {
+            let shuffled_words = shuffle(possible_words);
+            words_textarea.value = shuffled_words.slice(0, 57).join("\n");
+        }
+
+        // Updates the word count
+        function update_word_count() {
+            const lines = words_textarea.value.split(/\n+/g).filter((w) => w !== "");
+            word_count.innerHTML = lines.length;
+        }
+
+        // Event handlers
+        words_textarea.addEventListener("input", update_word_count);
+        words_textarea.addEventListener("change", update_word_count);
+        generate_words_btn.addEventListener("click", (e) => {
+            e.preventDefault();
+            generate_words(possible_words);
+            update_word_count();
+        });
+    }
+
+    $(document).ready(initialize);
+})(jQuery);

--- a/parser_tool/templates/parser_tool/playing_with_matches_options.html
+++ b/parser_tool/templates/parser_tool/playing_with_matches_options.html
@@ -12,6 +12,9 @@
 {% endblock %}
 
 {% block extra_script %}
+    {{ possible_words|json_script:"possible_words_data" }}
+    <script src="{% static 'js/src/lib/utils.js' %}"></script>
+    <script src="{% static 'js/src/playing_with_matches_options.js' %}"></script>
 {% endblock %}
 
 
@@ -19,6 +22,9 @@
 <a name="top"></a>
 <div class="row" style="background-color: #f7f7f7">
     <div class="col-md-1"></div>
+    <div class="col-md-10 mt-3">
+        <h2>Playing With Matches</h2>
+    </div>
 </div>
 <div class="row" style="background-color: #f7f7f7">
     <div class="col-md-1"></div>
@@ -35,11 +41,24 @@
                     {{ field.label_tag }} {{ field }}
                 {% endfor %}
             </div>
-            <br>
-            <button class="btn btn-dark my-4" type="submit">Submit</button>
+            <div>Words entered: <span id="wordcount">0</span></div>
+            <button class="btn btn-primary" type="submit">Start Game</button>
+            <button class="btn btn-secondary my-4" id="generate-words">Generate Words</button>
     </form>
-       
     </div>
 </div>
+<div class="row mt-4 mb-4">
+    <div class="col-md-1"></div>
+    <div class="col-md-10">
+    <h3>Word Bank</h3>
+    <p>Select from the following list of {{ possible_words|length }} words to use in <i>Playing with Matches</i>:</p>
+    <div style="column-count: 4;">
+        {% for word in possible_words %}
+            {{  word }}<br>
+        {% endfor %}
+    </div>
+    </div>
+</div>
+
 
 {% endblock %}

--- a/parser_tool/templates/parser_tool/playing_with_matches_start_game.html
+++ b/parser_tool/templates/parser_tool/playing_with_matches_start_game.html
@@ -73,6 +73,12 @@
 {% block content %}
 <a name="top"></a>
 <div class="row" style="background-color: #f7f7f7">
+    <div class="col-md-1"></div>
+    <div class="col-md-10 mt-3">
+        <h2>Playing With Matches</h2>
+    </div>
+</div>
+<div class="row mb-4" style="background-color: #f7f7f7;">
     <div class="col-md-10 mt-5">
         <div id="central-card"class="mr-4 mb-5">Placeholder central card</div>
         <div class="d-flex justify-content-between">

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,0 @@
-'''
-helper function to find the diff in two different list
-'''
-def list_diff(list1, list2):
-    return (set(list1).symmetric_difference(set(list2)))

--- a/visualizing_russian_tools/templates/homepage.html
+++ b/visualizing_russian_tools/templates/homepage.html
@@ -78,8 +78,8 @@
         <div class="card">
             <div class="card-header">Playing with Matches</div>
             <div class="card-body">
-                <p class="card-text">Playing with Matches Game</p>
-                <a href="{% url 'playing_with_matches' %}" class="btn btn-primary">Start Playing with Matches Game</a>
+                <p class="card-text">A vocabulary game to find matching images quickly.</p>
+                <a href="{% url 'playing_with_matches' %}" class="btn btn-primary">Enter Playing with Matches</a>
             </div>
         </div>
     </div>

--- a/visualizing_russian_tools/templates/theme_base.html
+++ b/visualizing_russian_tools/templates/theme_base.html
@@ -50,6 +50,7 @@
                         <!-- =<a class="dropdown-item" id="nav-item-verb-radar-charts" href="{% url 'verb_radar_chart' %}">Verb Radar Chart</a> -->
                         <a class="dropdown-item" id="nav-item-similarity" href="{% url 'similarity' %}">Similarity Tool</a>
                         <a class="dropdown-item" id="nav-item-html-colorizer" href="{% url 'html_colorizer' %}">HTML Colorizer</a>
+                        <a class="dropdown-item" id="nav-item-playing-with-matches" href="{% url 'playing_with_matches' %}">Playing With Matches</a>
                         <a class="dropdown-item" id="nav-item-verb-histograms" href="{% url 'verb_histograms' %}">Verb Histograms</a>
                     </div>
                 </li>

--- a/visualizing_russian_tools/urls.py
+++ b/visualizing_russian_tools/urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
     path('case-distribution', parser_tool.views.case_distribution,  name='case_distribution'),
     path('verb-radar-chart', parser_tool.views.verb_radar_chart,  name='verb_radar_chart'),
     path('similarity', parser_tool.views.similarity,  name='similarity'),
-    path('playing-with-matches', parser_tool.views.playing_with_matches,  name='playing_with_matches'),
+    path('playing-with-matches', parser_tool.views.PlayingWithMatchesView.as_view(),  name='playing_with_matches'),
     path('playing-with-matches-reset', parser_tool.views.playing_with_matches_reset,  name='playing_with_matches_reset'),
     path('verb_histograms', parser_tool.views.verb_histograms,  name='verb_histograms'),
 


### PR DESCRIPTION
This PR enhances the **Playing With Matches** game with the ability to quickly start a new game by generating words from the word bank.

Changes:
* Added ability to generate random words (57) to play the game.
* Added a "Word Bank" so the user can see words that can be used with the game.
* Updated the _Additional Tools_ navigation list to include _Playing With Matches_.
* Refactored the django view function into class-based view since it handles both GET and POST.
* Added `shuffle` to the JS utility functions, since it's generally useful.
* Inlined the `list_diff` utils function since it's performing a standard operation on sets.

Notes:
* The Word Bank currently just shows level 1E words with images. We'll probably want to enhance this functionality if/when more words are supported with images. This is just a first pass at providing usable information.

See also: ATGU-3594
