### PR TITLE
Add alternate version of visible vocabulary tool for textbook creation

### DIFF
--- a/parser_tool/static/css/text_parsing_analysis.css
+++ b/parser_tool/static/css/text_parsing_analysis.css
@@ -8,12 +8,19 @@
     white-space: pre-wrap; /* Note: this seems to help with copy & paste to word... */
     color: black; /* Ensure that non-word characters (e.g. space and punctuation) is black */
 }
+.parser-input {
+    padding: 36px 0 0 0;
+    background-color: #f7f7f7;
+}
+.parser-header {
+    color: #777777;
+}
 
 pre.words {
     color: black;
-    font-size: 18px;
+    font-family: inherit; /* Note: should inherit Lato from the body, overriding default mono font */
+    font-size: 12pt; /* Note: sclancy requested 12pt */
     tab-size: 8; /* tab entities - &x9; or &tab; - only render in "pre" elements */
-    font-family: Lato, sans-serif;
     white-space: pre-wrap; /* css-3 */
     white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
     white-space: -pre-wrap; /* Opera 4-6 */
@@ -84,16 +91,16 @@ pre.words.mask.level4 .word:not(.level4) {
 /* miscellaneous text */
 .underline { text-decoration: underline; }
 .indent { margin-left: 3em; }
-.wordinfo-heading { 
+.wordinfo-heading {
     font-weight: bold;
  }
-ul.wordinfo-details { 
-    list-style-type: none; 
-    margin-inline-start: 20px;  
+ul.wordinfo-details {
+    list-style-type: none;
+    margin-inline-start: 20px;
     padding-left: 0; }
-ul.wordinfo-details i { 
-    font-style: normal; 
-    color: #990000; 
+ul.wordinfo-details i {
+    font-style: normal;
+    color: #990000;
 }
 
 /* resize heading elements inside the container */

--- a/parser_tool/templates/parser_tool/text_parsing_analysis.html
+++ b/parser_tool/templates/parser_tool/text_parsing_analysis.html
@@ -9,15 +9,13 @@
     {{ block.super }}
 <link rel="stylesheet" type="text/css" href="{% static 'css/components.css' %}" />
 <link rel="stylesheet" type="text/css" href="{% static 'css/text_parsing_analysis.css' %}" />
+{% if textbook_mode %}
 <style>
-.parser-input {
-    padding: 36px 0 0 0;
-    background-color: #f7f7f7;
-}
-.parser-header {
-    color: #777777;
-}
+    pre.words {
+        font-family: Cambria, serif;
+    }
 </style>
+{% endif %}
 {% endblock %}
 
 {% block extra_script %}
@@ -31,11 +29,13 @@
     <script src="{% static 'js/src/lib/gauges.js' %}"></script>
     <script src="{% static 'js/src/lib/charts.js' %}"></script>
     <script src="{% static 'js/src/lib/components.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/src/text_parsing_analysis.js' %}"></script>
+    <script src="{% static 'js/src/text_parsing_analysis.js' %}"></script>
 {% endblock %}
 
 
 {% block content %}
+
+
 <div class="row parser-container parser-input">
     <div class="col-md-9 offset-1">
         <div class="mb-4">

--- a/parser_tool/views.py
+++ b/parser_tool/views.py
@@ -10,8 +10,11 @@ from .forms import WordListForm
 
 logger = logging.getLogger(__name__)
 
-def text_parsing_analysis(request):
-    return render(request, 'parser_tool/text_parsing_analysis.html')
+def text_parsing_analysis(request, **kwargs):
+    context = {
+        "textbook_mode": kwargs.get("textbook_mode"),
+    }
+    return render(request, 'parser_tool/text_parsing_analysis.html', context)
 
 
 def mini_story_creator(request):

--- a/visualizing_russian_tools/static/css/base.css
+++ b/visualizing_russian_tools/static/css/base.css
@@ -5,6 +5,7 @@ body {
     display: flex;
     min-height: 100vh;
     flex-direction: column;
+    font-family: Lato, sans-serif;
 }
 main {
     flex: 3;
@@ -16,11 +17,6 @@ footer {
     background-color: rgba(0, 0, 0, 0.03);
     border-top: 1px solid #ccc;
     padding: 20px 0;
-}
-
-.container,
-.container-fluid {
-    font-family: Lato, sans-serif;
 }
 
 .theme-default {

--- a/visualizing_russian_tools/templates/homepage.html
+++ b/visualizing_russian_tools/templates/homepage.html
@@ -13,6 +13,7 @@
         <div class="card-body">
             <p class="card-text">Visualize the relative difficulty of a Russian text based on core, foundation, expansion, and specialization vocabulary. Words are colorized according to their level.</p>
             <a href="{% url 'text_parsing_analysis' %}" class="btn btn-primary">Enter Visible Vocabulary</a>
+            <a href="{% url 'text_parsing_analysis_textbook' %}" class="btn btn-secondary">Textbook Creation</a>
         </div>
     </div>
 </div>

--- a/visualizing_russian_tools/urls.py
+++ b/visualizing_russian_tools/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
 
     # Tool pages
     path('text-parsing-analysis', parser_tool.views.text_parsing_analysis,  name='text_parsing_analysis'),
+    path('text-parsing-analysis-textbook', parser_tool.views.text_parsing_analysis,  name='text_parsing_analysis_textbook', kwargs={'textbook_mode': True}),
     path('html-colorizer', parser_tool.views.html_colorizer,  name='html_colorizer'),
     path('mini-story-creator', parser_tool.views.mini_story_creator,  name='mini_story_creator'),
     path('quick-lemma', parser_tool.views.quick_lemma,  name='quick_lemma'),


### PR DESCRIPTION
Add alternate version of **Visible Vocabulary** tool for textbook creation, as requested by Steven on 5/30/23.

Changes:
- Added `textbook_mode` flag to the `text_parsing_analysis.html` template which will set the output font to Cambria instead of Lato (the default) when enabled.
- Added dedicated URL path to `visualizing_russian_tools/urls.py` that enables the `textbook_mode` flag on the django view.
- Added button to `homepage.html` to make it easy to access the textbook mode.

This is intended for use in the development environment as a temporary measure to facilitate textbook creation. To make this change more permanent, an appropriate UI will need to be created.