### PR TITLE
Add Journal Article to Footer

### DIFF
--- a/visualizing_russian_tools/templates/about.html
+++ b/visualizing_russian_tools/templates/about.html
@@ -13,10 +13,17 @@
         <h2>What is Visualizing Russian?</h2>
         <p>Visualizing Russian is a suite of web-based tools for language learners, researchers, and teachers created by <a href="mailto:sclancy@fas.harvard.edu>">Steven Clancy</a>.</p>
 
+        <h2>Articles</h2>
+        <p>
+            <cite>Clancy, Steven J. and Lee, Paige (2022) "Visualizing Russian: Illuminating Corpora, Conjugations, and Classrooms," Russian Language Journal: Vol. 72: Iss. 1, Article 2.</cite>
+            <br>
+            Available at: <a href="https://scholarsarchive.byu.edu/rlj/vol72/iss1/2">https://scholarsarchive.byu.edu/rlj/vol72/iss1/2</a>
+        </p>
+
         <h2>Handouts</h2>
         <p><a href="{% static 'handouts/ClancyPrincetonPresentation28October2021.pdf' %}">Visualizing Russian: Teaching Vocabulary at the
             Intersection of Frequency, Grammar, and
-            Communication</a>.</p>
+            Communication</a> (2021).</p>
 
         <h2>Code and data</h2>
         <p><a href="https://github.com/harvard-atg/visualizing_russian_tools">https://github.com/harvard-atg/visualizing_russian_tools</a></p>

--- a/visualizing_russian_tools/templates/theme_base.html
+++ b/visualizing_russian_tools/templates/theme_base.html
@@ -79,6 +79,11 @@
                     <h5>Visualizing Russian © 2014-{% now "Y" %} Steven Clancy</h5>
                     <p>For questions or further information about the project, please contact Steven Clancy &lt;<a href="mailto:sclancy@fas.harvard.edu">sclancy@fas.harvard.edu</a>&gt;.</p>
                     <p>Citation:<br><cite>Clancy, Steven. Visualizing Russian. A suite of tools for exploring the data behind the Russian language, 2014-{% now "Y" %}, (<a href="http://visualizingrussian.fas.harvard.edu">http://visualizingrussian.fas.harvard.edu</a>).</cite></p>
+                    <p>
+                        Read the recent article about the project:<br>
+                        <cite>Clancy, Steven J. and Lee, Paige (2022) "Visualizing Russian: Illuminating Corpora, Conjugations, and Classrooms," Russian Language Journal: Vol. 72: Iss. 1, Article 2.</cite><br>
+                        Available at: <a href="https://scholarsarchive.byu.edu/rlj/vol72/iss1/2">https://scholarsarchive.byu.edu/rlj/vol72/iss1/2</a>
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR adds a link to the published journal article (https://scholarsarchive.byu.edu/rlj/vol72/iss1/2/). 

Changes:
* Added article to footer per Steven's request.
* Added article to about page.