### PR TITLE
Update HTML page title

### DIFF
--- a/visualizing_russian_tools/templates/theme_base.html
+++ b/visualizing_russian_tools/templates/theme_base.html
@@ -6,8 +6,8 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="Russian Modules is a textbook companion website for students as well as a suite of tools.">
-    <title>{% block head_title_base %}{% block head_title %}{% endblock %} | "Russian Modules"{% endblock %}</title>
+    <meta name="description" content="Visualizing Russian is a textbook companion website for students as well as a suite of tools.">
+    <title>{% block head_title_base %}{% block head_title %}{% endblock %} | Visualizing Russian{% endblock %}</title>
     <link rel="icon" type="image/png" sizes="32x32" href="{% static 'img/favicon-32x32.png' %}">
     <link rel="icon" type="image/png" sizes="16x16" href="{% static 'img/favicon-16x16.png' %}">
     <link rel="shortcut icon" href="{% static 'img/favicon.ico' %}" />


### PR DESCRIPTION
This PR updates the HTML page title element so it defaults to **Visualizing Russian** instead of **Russian Modules**, which was the old name of the site.

## Changes

- Updated the `title` element in `theme_base.html` so it now shows **Page | Visualizing Russian**.
- Update the `meta` tag description as well.

FYI @jaguillette 