### PR TITLE
GCP Deploys

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,6 +1,9 @@
-name: Publish Docker Image
+name: Docker Build and Deploy
 
 on:
+  push:
+    branches:
+      - master
   release:
     types: [published]
   workflow_dispatch:
@@ -68,3 +71,36 @@ jobs:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  deploy-to-gcloud:
+    needs: build-and-push
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      GCP_SERVICE_NAME: visualizing-russian-tools
+      GCP_REGION: us-east4
+      GCP_PROJECT_ID: ${{ secrets.SUNSETTING_GCP_PROJECT_ID }}
+
+    steps:
+      - name: Google Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.SUNSETTING_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.SUNSETTING_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy to Google Cloud
+        run: |
+          # Construct the image path in the run step where variable substitution works
+          IMAGE_REPO="${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/github-upstream/visualizing-russian-tools/visualizing-russian-tools"
+
+          gcloud run deploy ${{ env.GCP_SERVICE_NAME }} \
+            --image ${IMAGE_REPO}:${{ github.event.release.tag_name }} \
+            --region ${{ env.GCP_REGION }}
+          echo "Deployed version ${{ github.event.release.tag_name }} to Google Cloud Run service ${{ env.GCP_SERVICE_NAME }} in region ${{ env.GCP_REGION }}"

--- a/visualizing_russian_tools/settings/gcp.py
+++ b/visualizing_russian_tools/settings/gcp.py
@@ -1,0 +1,35 @@
+import os
+from urllib.parse import urlparse
+
+from .base import *  # noqa: F403
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# Fail if the secret key is not set
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "ERROR")
+
+# Hostnames
+# https://cloud.google.com/python/django/run#csrf_configurations
+ALLOWED_HOSTS_ENV = os.environ.get("ALLOWED_HOSTS", None)
+if ALLOWED_HOSTS_ENV:
+    CSRF_TRUSTED_ORIGINS = os.environ.get("ALLOWED_HOSTS").split(",")
+    ALLOWED_HOSTS = [urlparse(url).netloc for url in CSRF_TRUSTED_ORIGINS]
+    SECURE_SSL_REDIRECT = True
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+else:
+    ALLOWED_HOSTS = ["*"]
+
+# Database configuration
+# For GCP Cloud Run ("sunsetting environment") we are baking the data layer into the container,
+# so we use the same SQLite database as the local settings.
+
+# Static files
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+
+# Cors headers
+# CORS_ORIGIN_WHITELIST = [origin for origin in os.environ.get('CORS_ORIGIN_WHITELIST', '').split(' ') if origin]
+CORS_ORIGIN_ALLOW_ALL = True


### PR DESCRIPTION
# Overview
Add a new `settings/gcp.py` config, and update the build pipeline to include a deploy step. This is triggered on package release publication. The deploy relies on GCP Workload Identity Provider with org-level secrets to create the OAuth connection; it might take some iterations to get this working as it seems hard to test.

# Changes

# Notes

# References
