### PR TITLE
Need to checkout code to auth in later steps

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -81,15 +81,18 @@ jobs:
       GCP_PROJECT_ID: ${{ secrets.SUNSETTING_GCP_PROJECT_ID }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Google Auth
         id: auth
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.SUNSETTING_GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.SUNSETTING_GCP_SERVICE_ACCOUNT }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
 
       - name: Deploy to Google Cloud
         run: |


### PR DESCRIPTION
Needs to write create_credentials_file, so we need to checkout the repo.

Fixed the provider in GCP to use our GH Enterprise issuer: `"The issuer in ID Token https://token.actions.githubusercontent.com/harvard-university does not match the expected ones: https://token.actions.githubusercontent.com."`