### PR TITLE
Fix MWE combining acute accent parser issue

### DIFF
--- a/parser_tool/tests/test_tokenizer.py
+++ b/parser_tool/tests/test_tokenizer.py
@@ -167,6 +167,36 @@ class TestTokenizer(unittest.TestCase):
                 "text": "Во время встречи он встал и вышел в коридор. В это время мы еще не поняли, в чем дело.",
                 "occurrences": 1,
             },
+            {
+                "mwe": "Во-первых",
+                "text": "Во-первых, нужно понять суть проблемы.",
+                "occurrences": 1,
+            },
+            {
+                "mwe": "Во-вторых",
+                "text": "Во-вторых, следует найти решение.",
+                "occurrences": 1,
+            },
+            {
+                "mwe": "В-третьих",
+                "text": "В-третьих, нужно проверить результат.",
+                "occurrences": 1,
+            },
+            {
+                "mwe": "Во-первы́х",
+                "text": "Во-первы́х, это очень важно.",
+                "occurrences": 1,
+            },
+            {
+                "mwe": "Во-вторы́х",
+                "text": "Во-вторы́х, нужно быть осторожным.",
+                "occurrences": 1,
+            },
+            {
+                "mwe": "В-тре́тьих",
+                "text": "В-тре́тьих, это последний пункт.",
+                "occurrences": 1,
+            },
         ]
         for test in tests:
             (mwe, text, expected_occurrences) = test["mwe"], test["text"], test["occurrences"]

--- a/parser_tool/tokenizer.py
+++ b/parser_tool/tokenizer.py
@@ -276,10 +276,15 @@ def split_hyphenated(tokens, hyphen_char=HYPHEN_CHAR, reserved_words=HYPHENATED_
     """
     Splits hyphenated tokens, handling special cases like "по-" words, which should not be split.
     """
+    # Create a set of canonical forms of reserved words for faster lookup
+    canonical_reserved_words = {canonical(word) for word in reserved_words}
+
     new_tokens = []
     for token in tokens:
         # split hyphenated unless it's a special case like "по-" words (DB entries for those)
-        if hyphen_char in token and not token.startswith("по-") and token not in reserved_words:
+        if (hyphen_char in token and
+            not token.lower().startswith("по-") and
+            canonical(token) not in canonical_reserved_words):
             for t in re.split(r"(%s)" % hyphen_char, token):
                 if t != "":
                     new_tokens.append(t)

--- a/parser_tool/tokenizer.py
+++ b/parser_tool/tokenizer.py
@@ -282,9 +282,7 @@ def split_hyphenated(tokens, hyphen_char=HYPHEN_CHAR, reserved_words=HYPHENATED_
     new_tokens = []
     for token in tokens:
         # split hyphenated unless it's a special case like "по-" words (DB entries for those)
-        if (hyphen_char in token and
-            not token.lower().startswith("по-") and
-            canonical(token) not in canonical_reserved_words):
+        if hyphen_char in token and not token.lower().startswith("по-") and canonical(token) not in canonical_reserved_words:
             for t in re.split(r"(%s)" % hyphen_char, token):
                 if t != "":
                     new_tokens.append(t)


### PR DESCRIPTION
Fixes tokenizer to properly handle Russian ordinal adverbs (во-первых, во-вторых, в-третьих) with combining acute accent marks as single tokens.

## Changes

- Updated the `split_hyphenated` function in `tokenizer.py`: Added canonical comparison to handle both accented and unaccented versions of hyphenated words
- Case-insensitive handling: Updated "по-" prefix check to be case-insensitive
- Unit tests: Added tests for both accented (во-первы́х, во-вторы́х, в-тре́тьих) and unaccented versions with proper capitalization

## Notes

The tokenizer now uses canonical forms (stripped of diacritics and lowercased) when comparing against reserved hyphenated words, ensuring that variations like "Во-первых" and "во-первы́х" are both preserved as single tokens instead of being split at the hyphen.